### PR TITLE
Fix BerkeleyDB build on modern compilers

### DIFF
--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -70,6 +70,8 @@ RUN PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') && \
         --enable-cxx \
         --disable-shared \
         --with-pic \
+        --with-bdb-libdir=/usr/local/lib \
+        --with-bdb-includedir=/usr/local/include \
         LDFLAGS="-L/usr/local/lib/" \
         CPPFLAGS="-I/usr/local/include/" && \
     make

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -23,6 +23,10 @@ RUN wget http://download.oracle.com/berkeley-db/db-4.8.30.NC.tar.gz && \
 RUN tar -xzvf db-4.8.30.NC.tar.gz && \
     echo "Tar extraction completed."
 
+# Patch BerkeleyDB for modern compilers
+RUN sed -i 's/__atomic_compare_exchange/__atomic_compare_exchange_db/' db-4.8.30.NC/dbinc/atomic.h && \
+    sed -i 's/atomic_init/atomic_init_db/' db-4.8.30.NC/dbinc/atomic.h db-4.8.30.NC/mp/mp_region.c db-4.8.30.NC/mp/mp_mvcc.c db-4.8.30.NC/mp/mp_fget.c db-4.8.30.NC/mutex/mut_method.c db-4.8.30.NC/mutex/mut_tas.c
+
 # Configure BerkeleyDB
 RUN cd db-4.8.30.NC/build_unix && \
     ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=/usr/local && \

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -24,11 +24,18 @@ RUN tar -xzvf db-4.8.30.NC.tar.gz && \
     echo "Tar extraction completed."
 
 # Patch BerkeleyDB for modern compilers
-RUN sed -i 's/__atomic_compare_exchange/__atomic_compare_exchange_db/' db-4.8.30.NC/dbinc/atomic.h && \
-    sed -i 's/atomic_init/atomic_init_db/' db-4.8.30.NC/dbinc/atomic.h db-4.8.30.NC/mp/mp_region.c db-4.8.30.NC/mp/mp_mvcc.c db-4.8.30.NC/mp/mp_fget.c db-4.8.30.NC/mutex/mut_method.c db-4.8.30.NC/mutex/mut_tas.c
+RUN sed -i.old 's/__atomic_compare_exchange/__atomic_compare_exchange_db/' db-4.8.30.NC/dbinc/atomic.h && \
+    sed -i.old 's/atomic_init/atomic_init_db/' db-4.8.30.NC/dbinc/atomic.h \
+        db-4.8.30.NC/mp/mp_region.c \
+        db-4.8.30.NC/mp/mp_mvcc.c \
+        db-4.8.30.NC/mp/mp_fget.c \
+        db-4.8.30.NC/mutex/mut_method.c \
+        db-4.8.30.NC/mutex/mut_tas.c && \
+    cp /usr/share/misc/config.guess /usr/share/misc/config.sub db-4.8.30.NC/dist
 
 # Configure BerkeleyDB
 RUN cd db-4.8.30.NC/build_unix && \
+    CXXFLAGS="-std=c++11" \
     ../dist/configure --enable-cxx --disable-shared --with-pic --prefix=/usr/local && \
     echo "Configuration completed."
 
@@ -49,7 +56,7 @@ COPY . /src/CmusicAI
 # Build CmusicAI for Linux
 WORKDIR /src/CmusicAI
 RUN ./autogen.sh && \
-    ./configure LDFLAGS="-L/usr/local/lib/" CPPFLAGS="-I/usr/local/include/" --enable-cxx --disable-shared --with-pic --with-bdb-libdir=/usr/local/lib --with-bdb-includedir=/usr/local/include && \
+    ./configure LDFLAGS="-L/usr/local/lib/" CPPFLAGS="-I/usr/local/include/" CXXFLAGS="-std=c++11" --enable-cxx --disable-shared --with-pic --with-bdb-libdir=/usr/local/lib --with-bdb-includedir=/usr/local/include && \
     make
 
 # Windows cross-compilation stage
@@ -73,7 +80,8 @@ RUN PATH=$(echo "$PATH" | sed -e 's/:\/mnt.*//g') && \
         --with-bdb-libdir=/usr/local/lib \
         --with-bdb-includedir=/usr/local/include \
         LDFLAGS="-L/usr/local/lib/" \
-        CPPFLAGS="-I/usr/local/include/" && \
+        CPPFLAGS="-I/usr/local/include/" \
+        CXXFLAGS="-std=c++11" && \
     make
 
 # Final stage to gather all binaries

--- a/Dockerfile.build
+++ b/Dockerfile.build
@@ -24,14 +24,15 @@ RUN tar -xzvf db-4.8.30.NC.tar.gz && \
     echo "Tar extraction completed."
 
 # Patch BerkeleyDB for modern compilers
-RUN sed -i.old 's/__atomic_compare_exchange/__atomic_compare_exchange_db/' db-4.8.30.NC/dbinc/atomic.h && \
-    sed -i.old 's/atomic_init/atomic_init_db/' db-4.8.30.NC/dbinc/atomic.h \
-        db-4.8.30.NC/mp/mp_region.c \
-        db-4.8.30.NC/mp/mp_mvcc.c \
-        db-4.8.30.NC/mp/mp_fget.c \
-        db-4.8.30.NC/mutex/mut_method.c \
-        db-4.8.30.NC/mutex/mut_tas.c && \
-    cp /usr/share/misc/config.guess /usr/share/misc/config.sub db-4.8.30.NC/dist
+RUN cd db-4.8.30.NC && \
+    sed -i 's/__atomic_compare_exchange(/__atomic_compare_exchange_db(/' dbinc/atomic.h && \
+    sed -i 's/atomic_init(/atomic_init_db(/' dbinc/atomic.h \
+        mp/mp_region.c \
+        mp/mp_mvcc.c \
+        mp/mp_fget.c \
+        mutex/mut_method.c \
+        mutex/mut_tas.c && \
+    cp /usr/share/misc/config.guess /usr/share/misc/config.sub dist/
 
 # Configure BerkeleyDB
 RUN cd db-4.8.30.NC/build_unix && \


### PR DESCRIPTION
## Summary
- patch Dockerfile.build so BerkeleyDB compiles with GCC

## Testing
- `docker` command not available in environment

------
https://chatgpt.com/codex/tasks/task_e_6875907597208331af51c343886dafa0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated build process to apply compatibility patches to BerkeleyDB during image creation.
  * Ensured consistent C++11 compilation flags and explicit BerkeleyDB directory settings across build environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->