### PR TITLE
Add wallet balance checker script

### DIFF
--- a/assets/tools/README.md
+++ b/assets/tools/README.md
@@ -51,3 +51,17 @@ Optional Arguments
  ```
 Run: ```python ipfs_pinner.py```
 
+
+### Wallet Balance Checker
+Retrieve the current wallet balance via RPC using Node.js.
+
+This script reads the following environment variables:
+- `RPC_USER`
+- `PRC_PASSWORD` or `RPC_PASSWORD`
+- `RPC_IP`
+- `RPC_PORT`
+
+Run it with:
+```
+node check_wallet_balance.js
+```

--- a/assets/tools/check_wallet_balance.js
+++ b/assets/tools/check_wallet_balance.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+const http = require('http');
+
+const RPC_USER = process.env.RPC_USER;
+// Allow both PRC_PASSWORD and RPC_PASSWORD for flexibility
+const RPC_PASSWORD = process.env.PRC_PASSWORD || process.env.RPC_PASSWORD;
+const RPC_IP = process.env.RPC_IP || '127.0.0.1';
+const RPC_PORT = process.env.RPC_PORT || 9819;
+
+if (!RPC_USER || !RPC_PASSWORD) {
+  console.error('Missing RPC credentials. Set RPC_USER and PRC_PASSWORD (or RPC_PASSWORD).');
+  process.exit(1);
+}
+
+const postData = JSON.stringify({
+  jsonrpc: '2.0',
+  id: 1,
+  method: 'getbalance',
+  params: []
+});
+
+const options = {
+  hostname: RPC_IP,
+  port: RPC_PORT,
+  method: 'POST',
+  path: '/',
+  headers: {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(postData),
+    'Authorization': 'Basic ' + Buffer.from(`${RPC_USER}:${RPC_PASSWORD}`).toString('base64')
+  }
+};
+
+const req = http.request(options, (res) => {
+  let data = '';
+  res.on('data', chunk => data += chunk);
+  res.on('end', () => {
+    try {
+      const parsed = JSON.parse(data);
+      if (parsed.error) {
+        console.error('RPC error:', parsed.error);
+        process.exit(1);
+      }
+      console.log('Wallet balance:', parsed.result);
+    } catch (err) {
+      console.error('Failed to parse RPC response:', err.message);
+      process.exit(1);
+    }
+  });
+});
+
+req.on('error', (err) => {
+  console.error('Request error:', err.message);
+  process.exit(1);
+});
+
+req.write(postData);
+req.end();


### PR DESCRIPTION
## Summary
- add `check_wallet_balance.js` tool for checking wallet balance via RPC
- document how to run the balance checker in tools README

## Testing
- `RPC_USER=test RPC_PASSWORD=test node assets/tools/check_wallet_balance.js` (fails to connect because no RPC server)

------
https://chatgpt.com/codex/tasks/task_e_68759e17a7d48331bc54411cebb6c6c1

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a command-line tool to check wallet balances via RPC.
  
* **Documentation**
  * Added instructions and environment variable details for using the wallet balance checker in the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->